### PR TITLE
wait for 3 minutes before scanning again

### DIFF
--- a/xDripG5/BluetoothManager.swift
+++ b/xDripG5/BluetoothManager.swift
@@ -149,7 +149,7 @@ class BluetoothManager: NSObject {
             self.scanForPeripheral(after: TimeInterval(60 * 3))
         } else {
             DispatchQueue.global(qos: DispatchQoS.QoSClass.utility).async {
-                Thread.sleep(forTimeInterval: 2)
+                Thread.sleep(forTimeInterval: 60 * 3)
 
                 self.scanForPeripheral()
             }


### PR DESCRIPTION
In iOS versions < 11.2, the app waits for 2 seconds after reading from the transmitter before scanning again. Often the transmitter is still advertising, accepts the app's request to connect, but fails at the authentication step. Is there any reason why we can't use a 3 minute wait here, as we do for iOS 11.2 and above?