### PR TITLE
check glucose >= 40

### DIFF
--- a/xDripG5/Glucose.swift
+++ b/xDripG5/Glucose.swift
@@ -58,7 +58,7 @@ public struct Glucose {
     }
 
     public var glucose: HKQuantity? {
-        guard state.hasReliableGlucose else {
+        guard state.hasReliableGlucose && glucoseMessage.glucose >= 40 else {
             return nil
         }
 


### PR DESCRIPTION
I have observed occasionally that the state `.needCalibration14` coincides with an unreliable glucose reading ('---'). Presumably, if an entered calibration is too far off the regression line, the logic is to stop supplying glucose readings until a new calibration has been provided. On these occasions (and also all states for which `hasReliableGlucose` is `false` the glucose bytes in the glucose Rx message are `0500` (a 'glucose' of 5 mg/dL).

With this PR, the `glucose` property in `Glucose` returns `nil` if `glucoseMessage.glucose` is less than 40 (the range of the Dex system is 40 - 400 mg/dL).

Incidentally, since the glucose bytes in the glucose Rx message are always `0500` when the glucose is unreliable, it may be unnecessary to compute the `hasReliableGlucose` property in `CalibrationState` and check for it here.

Update: for some reason the glucose bytes are `0100` in the `.stopped` state (a 'glucose' of 1 mg/dL).  However, the logic here still holds.