### PR TITLE
Bump LoopKit version to fix Xcode build error

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "LoopKit/LoopKit" ~> 2.0
+github "LoopKit/LoopKit" ~> 2.2.2
 github "LoopKit/dexcom-share-client-swift" ~> 1.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "LoopKit/LoopKit" "v2.2.1"
+github "LoopKit/LoopKit" "v2.2.2"
 github "LoopKit/dexcom-share-client-swift" "v1.0"


### PR DESCRIPTION
Bumps LoopKit in Cartfile to `v2.2.2`, which fixes an Xcode build error in prior versions. See [LoopKit v2.2.2 release notes](https://github.com/LoopKit/LoopKit/releases/tag/v2.2.2).