### PR TITLE
Add bluetooth usage description to prevent crash in iOS 13.

### DIFF
--- a/ResetTransmitter/Info.plist
+++ b/ResetTransmitter/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>We need bluetooth access to reset the transmitter!</string>
 	<key>CFBundleDisplayName</key>
 	<string>Reset</string>
 	<key>CFBundleDevelopmentRegion</key>


### PR DESCRIPTION
I noticed that when I built and ran on my iOS 13 device, it crashed because it didn't have a description for `NSBluetoothAlwaysUsageDescription` so I added one.