### PR TITLE
Fixed building from directories containing space

### DIFF
--- a/CGMBLEKit.xcodeproj/project.pbxproj
+++ b/CGMBLEKit.xcodeproj/project.pbxproj
@@ -959,7 +959,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "${SRCROOT}/Scripts/copy-frameworks.sh\n";
+			shellScript = "\"${SRCROOT}/Scripts/copy-frameworks.sh\"\n";
 		};
 		43A8EC47210D097800A81379 /* Copy Frameworks with Carthage */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -981,7 +981,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "${SRCROOT}/Scripts/copy-frameworks.sh\n";
+			shellScript = "\"${SRCROOT}/Scripts/copy-frameworks.sh\"\n";
 		};
 		A93AF423225EE5DD002D9E0E /* Copy Frameworks with Carthage */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
SRCROOT environment variable is not escaped, when using it as part of a path it should be escaped or enclosed in quotes

Tested on workspaces build