### PR TITLE
updating for BT privacy for iOS 13

### DIFF
--- a/ResetTransmitter/Info.plist
+++ b/ResetTransmitter/Info.plist
@@ -47,5 +47,9 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>Bluetooth is used to communicate with continuous glucose monitor devices</string>
+	<key>NSBluetoothPeripheralUsageDescription</key>
+	<string>Bluetooth is used to communicate with continuous glucose monitor devices</string>
 </dict>
 </plist>


### PR DESCRIPTION
some resetTransmitter app users are getting the app crashing after building. Pretty sure this is the cause