### PR TITLE
Bug Fix: Added Bluetooth Privacy Info.plist for IOS 13

### DIFF
--- a/ResetTransmitter/Info.plist
+++ b/ResetTransmitter/Info.plist
@@ -47,5 +47,9 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSBluetoothPeripheralUsageDescription</key>
+	<string>The app needs bluetooth access to be able to process data from an IoT device in the background</string>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>The app needs bluetooth access to be able to process data from an IoT device in the background</string>	
 </dict>
 </plist>


### PR DESCRIPTION
On IOS 13, pressing Reset button crashes app with __CRASHING_DUE_TO_PRIVACY_VIOLATION__ error.  Fixed by adding NSBluetoothPeripheralUsageDescription and NSBluetoothAlwaysUsageDescription to Info.plist.